### PR TITLE
docs: CONTRIBUTING: Do not ask to init npm/yarn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,19 +58,9 @@ $ cd online-school
     git rebase upstream/main
     ```  
 
-**Step 3. Create a Package.json file and install Dependencies.**
+**Step 3. Install the project dependencies**
 
-- Using npm :
-    ```bash
-    $ npm init
-    ```
-
-- Using yarn : 
-    ```bash
-    $ yarn init
-    ```
-
-Next, we need to install the project dependencies, which are listed in `package.json`
+We need to install the project dependencies, which are listed in `package.json`
 
 - Using npm :
     ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ in case you are stuck:
 - [Forking a Repo](https://help.github.com/en/github/getting-started-with-github/fork-a-repo)
 - [Cloning a Repo](https://help.github.com/en/desktop/contributing-to-projects/creating-an-issue-or-pull-request)
 - [How to create a Pull Request](https://opensource.com/article/19/7/create-pull-request-github)
-- [Getting started with Git and GitHub](https://iread.ga/series/1/git-and-github)
+- [Getting started with Git and GitHub](https://www.freecodecamp.org/news/git-and-github-for-beginners)
 - [Learn GitHub from Scratch](https://lab.github.com/githubtraining/introduction-to-github)
 
 
@@ -133,5 +133,5 @@ You will see the build errors and warnings in the console.
 <h5 align="center">
 < Happy Contributing />
 <br>
-<a href="https://github.com/nightsailor">Muhammad Talha</a> | © 2021
+<a href="https://github.com/nightsailor">Muhammad Talha</a> | © 2022
 </h5>


### PR DESCRIPTION
The package.json file already exists in ./client and ./server. Therefore, we do not need to re-init the repository with `npm/yarn init`.

This commit will remove this unnecessary task from the contribution guidelines.


## PR Title

<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
#20 [DOCS] Remove the requirement to init npm/yarn from contribution guidelines

The purpose of this Pull Request is to fix #<issue-number>

## Description

<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
The purpose of npm/yarn init is to create a package.json. We already have package.json in ./client and ./server. Therefore, we do not need to npm/yarn init to build the project.

### Screenshots

<!---  Include an short video or screenshot if the change affects the UI.  -->

## Checklist

- [yes] I have Made this contribution as per the CONTRIBUTING guide in this repo
- [yes] I have tested in local Environment.
- [yes] I have made the fix as per issue converstaion
